### PR TITLE
Fetch after save

### DIFF
--- a/Service/SlidesInSlideDataCron.php
+++ b/Service/SlidesInSlideDataCron.php
@@ -91,6 +91,7 @@ class SlidesInSlideDataCron {
   /**
    * Check if it is necessary to fetch fresh data for the slide.
    *
+   * @param Slide $slide
    *
    * @return bool
    */


### PR DESCRIPTION
If the user has just saved a slide it is nicer if it then gets fresh data on next cron. Saves the user from sitting around waiting.