### PR TITLE
Catch subslide exceptions

### DIFF
--- a/Service/SlidesInSlideDataCron.php
+++ b/Service/SlidesInSlideDataCron.php
@@ -53,9 +53,9 @@ class SlidesInSlideDataCron {
 
       /**
        * We are running into issues, when we try to fetch data for more than ~25 slides in quick succession
-       * during a cron run. This issued is specifically caused by the kk.dk multisite system which drops 
+       * during a cron run. This issued is specifically caused by the kk.dk multisite system which drops
        * connections in such situations - probably to protect against DDoS attacks.
-       * To avoid triggering this we added a tiny sleep delay between each call. It may not be the most 
+       * To avoid triggering this we added a tiny sleep delay between each call. It may not be the most
        * efficient solution but it works for now.
        */
       sleep(0.5);
@@ -138,5 +138,5 @@ class SlidesInSlideDataCron {
 
     return $now > ($lastFetch + $dataTtl);
   }
-  
+
 }


### PR DESCRIPTION
Catch an handle any exceptions throw from subslides. If not OS2Display core will halt cron-processing when an exception is throw